### PR TITLE
Add command-line arguments (device name, monitor duration, poll interval)

### DIFF
--- a/tests/interfaceadapters/walkingpad/test_monitor.py
+++ b/tests/interfaceadapters/walkingpad/test_monitor.py
@@ -1,4 +1,6 @@
 import datetime as dt
+import signal
+from asyncio import TaskGroup, sleep
 from dataclasses import dataclass
 from types import ModuleType
 from typing import Any, Callable
@@ -21,7 +23,7 @@ class MonitorScenario:
     expected_post_query_params: dict[str, int | float | str] | None = None
 
 
-MONITOR_SCENARIOS = [
+MONITOR_DURATION_ELAPSED_SCENARIOS = [
     MonitorScenario(
         id="one walk, one stop",
         fake_walking_pad_cur_statuses=[
@@ -65,7 +67,15 @@ MONITOR_SCENARIOS = [
                 time=1201,
             ),
         ],
-        expected_post_call_count=0,
+        expected_post_call_count=1,
+        expected_post_query_params={
+            "date": "2038-04-01",
+            "startTime": "04:13",
+            "durationMillis": 1201000,
+            "distance": pytest.approx(1.253),
+            "activityId": 90019,
+            "distanceUnit": "Kilometer",
+        },
     ),
     MonitorScenario(
         id="two stop events",
@@ -79,6 +89,97 @@ MONITOR_SCENARIOS = [
                 belt_state=0,
                 dist=0,
                 time=0,
+            ),
+        ],
+        expected_post_call_count=0,
+    ),
+    MonitorScenario(
+        id="one walk, one unknown",
+        fake_walking_pad_cur_statuses=[
+            FakeWalkingPadCurStatus(
+                belt_state=1,
+                dist=125.3,
+                time=1201,
+            ),
+            FakeWalkingPadCurStatus(
+                belt_state=7,
+                dist=0,
+                time=0,
+            ),
+        ],
+        expected_post_call_count=1,
+        expected_post_query_params={
+            "date": "2038-04-01",
+            "startTime": "04:13",
+            "durationMillis": 1201000,
+            "distance": pytest.approx(1.253),
+            "activityId": 90019,
+            "distanceUnit": "Kilometer",
+        },
+    ),
+    MonitorScenario(
+        id="one stop, one walk",
+        fake_walking_pad_cur_statuses=[
+            FakeWalkingPadCurStatus(
+                belt_state=0,
+                dist=0,
+                time=0,
+            ),
+            FakeWalkingPadCurStatus(
+                belt_state=1,
+                dist=125.3,
+                time=1201,
+            ),
+        ],
+        expected_post_call_count=1,
+        expected_post_query_params={
+            "date": "2038-04-01",
+            "startTime": "04:13",
+            "durationMillis": 1201000,
+            "distance": pytest.approx(1.253),
+            "activityId": 90019,
+            "distanceUnit": "Kilometer",
+        },
+    ),
+]
+
+MONITORING_INTERRUPTED_SCENARIOS = [
+    MonitorScenario(
+        id="one walk, one stop",
+        fake_walking_pad_cur_statuses=[
+            FakeWalkingPadCurStatus(
+                belt_state=1,
+                dist=125.3,
+                time=1200,
+            ),
+            FakeWalkingPadCurStatus(
+                belt_state=0,
+                dist=0,
+                time=0,
+            ),
+        ],
+        expected_post_call_count=1,
+        expected_post_query_params={
+            "date": "2038-04-01",
+            "startTime": "04:13",
+            "durationMillis": 1200000,
+            "distance": pytest.approx(1.253),
+            "activityId": 90019,
+            "distanceUnit": "Kilometer",
+        },
+    ),
+    MonitorScenario(
+        id="two walk events",
+        fake_walking_pad_cur_statuses=[
+            FakeWalkingPadCurStatus(
+                belt_state=1,
+                dist=125.3,
+                time=1200,
+            ),
+            FakeWalkingPadCurStatus(
+                belt_state=1,
+                dist=125.3,
+                time=1201,
             ),
         ],
         expected_post_call_count=0,
@@ -120,11 +221,11 @@ MONITOR_SCENARIOS = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ids=[x.id for x in MONITOR_SCENARIOS],
+    ids=[x.id for x in MONITOR_DURATION_ELAPSED_SCENARIOS],
     argnames=["monitor_scenario"],
-    argvalues=[[x] for x in MONITOR_SCENARIOS],
+    argvalues=[[x] for x in MONITOR_DURATION_ELAPSED_SCENARIOS],
 )
-async def test_monitor(
+async def test_monitor_monitoring_duration_elapsed(
     monkeypatch: pytest.MonkeyPatch,
     treadmill_event_handler: TreadmillEventHandler,
     freeze_time: Callable[
@@ -136,7 +237,7 @@ async def test_monitor(
 ):
     """
     Given a scenario where the walking pad emits certain data
-    When we monitor the walking pad data
+    When we monitor the walking pad data until the monitoring duration elapses
     Then we send the expected api calls to Fitbit to log (or not) the activity.
     """
     with monkeypatch.context() as mp:
@@ -164,6 +265,71 @@ async def test_monitor(
             monitor_duration_s=1.0,
             poll_interval_s=0.1,
         )
+
+        # Then we send the expected api calls to Fitbit to log (or not) the activity.
+        assert (
+            authlib_mocks.post.call_count == monitor_scenario.expected_post_call_count
+        )
+        if monitor_scenario.expected_post_call_count:
+            actual_query_params = authlib_mocks.post.call_args[1]["params"]
+            assert actual_query_params == monitor_scenario.expected_post_query_params
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ids=[x.id for x in MONITORING_INTERRUPTED_SCENARIOS],
+    argnames=["monitor_scenario"],
+    argvalues=[[x] for x in MONITORING_INTERRUPTED_SCENARIOS],
+)
+async def test_monitor_monitoring_interrupted(
+    monkeypatch: pytest.MonkeyPatch,
+    treadmill_event_handler: TreadmillEventHandler,
+    freeze_time: Callable[
+        [pytest.MonkeyPatch, ModuleType, tuple[Any], dt.timezone], None
+    ],
+    fake_oauth_client: Callable[[pytest.MonkeyPatch, AuthLibScenario], AuthLibMocks],
+    fake_walking_pad: Callable[[pytest.MonkeyPatch, WalkingPadScenario], None],
+    monitor_scenario: MonitorScenario,
+):
+    """
+    Given a scenario where the walking pad emits certain data
+    When we monitor the walking pad data until an interrupt signal is sent
+    Then we send the expected api calls to Fitbit to log (or not) the activity.
+    """
+    with monkeypatch.context() as mp:
+
+        # Given a scenario where the walking pad emits certain data
+        freeze_time(
+            mp,
+            datetime_to_freeze,
+            frozen_datetime_args=(2038, 4, 1, 11, 33, 44, 0),
+            local_timezone=ZoneInfo("America/Los_Angeles"),
+        )
+        authlib_mocks: AuthLibMocks = fake_oauth_client(mp, AuthLibScenario())
+        fake_walking_pad(
+            mp,
+            WalkingPadScenario(
+                found_addresses=["some address"],
+                cur_statuses=monitor_scenario.fake_walking_pad_cur_statuses,
+            ),
+        )
+
+        async def send_interrupt_signal():
+            await sleep(1)
+            signal.raise_signal(signal.SIGINT)
+
+        # When we call the main() entry point
+        async with TaskGroup() as tg:
+            tg.create_task(
+                # When we monitor the walking pad data
+                monitor(
+                    device_name="some device",
+                    treadmill_event_handler=treadmill_event_handler,
+                    monitor_duration_s=None,
+                    poll_interval_s=0.1,
+                )
+            )
+            tg.create_task(send_interrupt_signal())
 
         # Then we send the expected api calls to Fitbit to log (or not) the activity.
         assert (

--- a/tests/interfaceadapters/walkingpad/test_monitor.py
+++ b/tests/interfaceadapters/walkingpad/test_monitor.py
@@ -161,8 +161,8 @@ async def test_monitor(
         await monitor(
             device_name="some device",
             treadmill_event_handler=treadmill_event_handler,
-            max_iterations=3,
-            sleep_duration_s=0.1,
+            monitor_duration_s=1.0,
+            poll_interval_s=0.1,
         )
 
         # Then we send the expected api calls to Fitbit to log (or not) the activity.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import signal
+import sys
 from asyncio import TaskGroup, sleep
 from typing import Callable
 
@@ -9,9 +10,16 @@ from tests.fixtures.ph4_walkingpad import WalkingPadScenario
 from walkingpadfitbit.auth import storage
 from walkingpadfitbit.main import main
 
+fake_oauth_token = {
+    "access_token": "some access token",
+    "expires_at": 1720908387,
+    "refresh_token": "some refresh token",
+    "user_id": "some user id",
+}
+
 
 @pytest.mark.asyncio
-async def test_main(
+async def test_main_required_args(
     monkeypatch: pytest.MonkeyPatch,
     fake_oauth_client: Callable[[pytest.MonkeyPatch, AuthLibScenario], AuthLibMocks],
     fake_walking_pad: Callable[[pytest.MonkeyPatch, WalkingPadScenario], None],
@@ -20,26 +28,21 @@ async def test_main(
     Given an authlib setup to provide successful responses,
     and no prior oauth token saved,
     And no connected walkingpad
-    When we call the main() entry point
+    When we call the main() entry point with required command-line arguments
     Then the authentication is successful
     And the oauth token is saved.
     """
     with monkeypatch.context() as mp:
 
         # Given an authlib setup to provide successful responses,
-        scenario = AuthLibScenario(
-            fake_oauth_token={
-                "access_token": "some access token",
-                "expires_at": 1720908387,
-                "refresh_token": "some refresh token",
-                "user_id": "some user id",
-            },
-        )
+        scenario = AuthLibScenario(fake_oauth_token=fake_oauth_token)
         fake_oauth_client(mp, scenario)
 
         # Given no connected walkingpad
         fake_walking_pad(mp, WalkingPadScenario())
 
+        # Simulate the user's command-line arguments.
+        mp.setattr(sys, "argv", ["main.py", "some device name"])
         # Simulate the user pasting the callback url.
         mp.setattr("builtins.input", lambda _: scenario.fake_callback_url)
 
@@ -55,6 +58,58 @@ async def test_main(
         async with TaskGroup() as tg:
             tg.create_task(main(env_file=".env.test"))
             tg.create_task(send_interrupt_signal())
+
+        # Then the authentication is successful
+        # And the oauth token is saved.
+        saved_token = storage.read_oauth_token()
+        assert saved_token is not None
+
+
+@pytest.mark.asyncio
+async def test_main_optional_args(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_oauth_client: Callable[[pytest.MonkeyPatch, AuthLibScenario], AuthLibMocks],
+    fake_walking_pad: Callable[[pytest.MonkeyPatch, WalkingPadScenario], None],
+):
+    """
+    Given an authlib setup to provide successful responses,
+    and no prior oauth token saved,
+    And no connected walkingpad
+    When we call the main() entry point with optional command-line arguments
+    Then the authentication is successful
+    And the oauth token is saved.
+    """
+    with monkeypatch.context() as mp:
+
+        # Given an authlib setup to provide successful responses,
+        scenario = AuthLibScenario(fake_oauth_token=fake_oauth_token)
+        fake_oauth_client(mp, scenario)
+
+        # Given no connected walkingpad
+        fake_walking_pad(mp, WalkingPadScenario())
+
+        # Simulate the user's command-line arguments.
+        mp.setattr(
+            sys,
+            "argv",
+            [
+                "main.py",
+                "--monitor-duration",
+                "1.0",
+                "--poll-interval",
+                "0.1",
+                "some device name",
+            ],
+        )
+        # Simulate the user pasting the callback url.
+        mp.setattr("builtins.input", lambda _: scenario.fake_callback_url)
+
+        # and no prior oauth token saved,
+        saved_token = storage.read_oauth_token()
+        assert saved_token is None
+
+        # When we call the main() entry point
+        await main(env_file=".env.test")
 
         # Then the authentication is successful
         # And the oauth token is saved.

--- a/walkingpadfitbit/domain/eventhandler.py
+++ b/walkingpadfitbit/domain/eventhandler.py
@@ -43,6 +43,11 @@ class TreadmillEventHandler:
                 distance_km=last_walk_event.dist_km,
             )
             asyncio.create_task(
-                self._remote_activity_repository.post_activity(activity)
+                self._remote_activity_repository.post_activity(activity),
+                name="post_activity",
             )
             self._last_walk_event = None
+
+    async def flush(self):
+        tasks = [t for t in asyncio.all_tasks() if t.get_name() == "post_activity"]
+        await asyncio.gather(*tasks)

--- a/walkingpadfitbit/interfaceadapters/cli/argparser.py
+++ b/walkingpadfitbit/interfaceadapters/cli/argparser.py
@@ -1,0 +1,35 @@
+import argparse
+from typing import Protocol
+
+
+class CliArgs(Protocol):
+    device_name: str
+    monitor_duration_s: float
+    poll_interval_s: float
+
+
+def parse_args() -> CliArgs:
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument(
+        "device_name",
+        help="Name of the walkingpad device (ex: KS-ST-A1P).",
+        type=str,
+    )
+    arg_parser.add_argument(
+        "-d",
+        "--monitor-duration",
+        help="Monitoring duration in seconds. By default the program monitors forever.",
+        type=float,
+        default=None,
+        dest="monitor_duration_s",
+    )
+    arg_parser.add_argument(
+        "-p",
+        "--poll-interval",
+        help="Poll interval in seconds (default %(default)s).",
+        type=float,
+        default=1.0,
+        dest="poll_interval_s",
+    )
+
+    return arg_parser.parse_args()

--- a/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
+++ b/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
@@ -87,6 +87,10 @@ async def monitor(
     while not program_end_event.is_set():
         await ctler.ask_stats()
         if stop_timestamp and time.time() > stop_timestamp:
+            # Send an event signaling the end of the walk, so it can be logged
+            # if it wasn't logged already:
+            treadmill_event_handler.handle_treadmill_event(TreadmillStopEvent)
+            await treadmill_event_handler.flush()
             break
         await sleep(poll_interval_s)
 

--- a/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
+++ b/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import signal
+import time
 from asyncio import sleep
 
 from ph4_walkingpad.pad import Controller, Scanner, WalkingPadCurStatus
@@ -50,8 +51,8 @@ def _to_treadmill_event(status: WalkingPadCurStatus) -> TreadmillEvent | None:
 async def monitor(
     device_name: str,
     treadmill_event_handler: TreadmillEventHandler,
-    max_iterations: int | None = None,
-    sleep_duration_s: float = 1.0,
+    monitor_duration_s: float | None = None,
+    poll_interval_s: float = 1.0,
 ):
     """
     1. Find the device with the given name.
@@ -78,13 +79,16 @@ async def monitor(
     await ctler.run(device_address)
 
     # 3. Loop, asking the controller for stats.
-    iterations = 0
-    while not program_end_event.is_set() and (
-        max_iterations is None or iterations < max_iterations
-    ):
+    start_timestamp = time.time()
+    stop_timestamp = (
+        start_timestamp + monitor_duration_s if monitor_duration_s else None
+    )
+
+    while not program_end_event.is_set():
         await ctler.ask_stats()
-        await sleep(sleep_duration_s)
-        iterations += 1
+        if stop_timestamp and time.time() > stop_timestamp:
+            break
+        await sleep(poll_interval_s)
 
     logger.info("Stop monitoring")
 

--- a/walkingpadfitbit/main.py
+++ b/walkingpadfitbit/main.py
@@ -4,6 +4,7 @@ import logging
 from walkingpadfitbit.auth.client import get_client
 from walkingpadfitbit.auth.config import Settings
 from walkingpadfitbit.domain.eventhandler import TreadmillEventHandler
+from walkingpadfitbit.interfaceadapters.cli.argparser import CliArgs, parse_args
 from walkingpadfitbit.interfaceadapters.cli.logincli import login_cli
 from walkingpadfitbit.interfaceadapters.fitbit.remoterepository import (
     FitbitRemoteActivityRepository,
@@ -19,6 +20,9 @@ async def main(
         level=logging.INFO,
         format="[%(asctime)s][%(levelname)-7s][%(name)-10s] %(message)s",
     )
+
+    # Get command-line arguments.
+    args: CliArgs = parse_args()
 
     # Log into Fitbit
     settings = Settings(_env_file=env_file)
@@ -37,8 +41,10 @@ async def main(
         remote_activity_repository=remote_activity_repository,
     )
     await monitor(
-        device_name="KS-ST-A1P",
+        device_name=args.device_name,
         treadmill_event_handler=treadmill_event_handler,
+        monitor_duration_s=args.monitor_duration_s,
+        poll_interval_s=args.poll_interval_s,
     )
 
 


### PR DESCRIPTION
* Require the device name to be provided.
* Add optional arguments for polling: monitor duration and poll interval. By default the program polls every second, forever (until it's terminated).