### PR TITLE
Catch a generic `Exception` when calling `Controller.run()`.

### DIFF
--- a/tests/interfaceadapters/walkingpad/test_monitor.py
+++ b/tests/interfaceadapters/walkingpad/test_monitor.py
@@ -230,12 +230,18 @@ MONITORING_INTERRUPTED_SCENARIOS = [
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ids=["no exception", "reconnect timeout", "bleak exception"],
+    ids=[
+        "no exception",
+        "reconnect timeout",
+        "bleak exception",
+        "unexpected error",
+    ],
     argnames="controller_run_exceptions",
     argvalues=[
         None,
         [None, TimeoutError],
         [None, BleakDeviceNotFoundError("my device")],
+        [None, ValueError("omg")],
     ],
 )
 @pytest.mark.parametrize(
@@ -307,12 +313,13 @@ async def test_monitor_monitoring_duration_elapsed(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ids=["no exception", "reconnect timeout", "bleak exception"],
+    ids=["no exception", "reconnect timeout", "bleak exception", "unexpected error"],
     argnames="controller_run_exceptions",
     argvalues=[
         None,
         [None, TimeoutError],
         [None, BleakDeviceNotFoundError("my device")],
+        [None, ValueError("omg")],
     ],
 )
 @pytest.mark.parametrize(

--- a/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
+++ b/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
@@ -101,7 +101,9 @@ async def monitor(
             except TimeoutError:
                 logger.warning("Timeout trying to reconnect")
             except BleakError as e:
-                logger.exception("Error trying to reconnect: %s", e)
+                logger.exception("BleakError trying to reconnect: %s", e)
+            except Exception as e:
+                logger.exception("Exception trying to reconnect: %s", e)
 
     logger.info("Stop monitoring")
 


### PR DESCRIPTION
This should handle this exception which was seen:

```
Name: Vendor specific, Value: None
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/jdoe/gitrepo/walkingpad-fitbit/walkingpadfitbit/main.py", line 52, in <module>
    asyncio.run(main())
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/jdoe/gitrepo/walkingpad-fitbit/walkingpadfitbit/main.py", line 43, in main
    await monitor(
  File "/Users/jdoe/gitrepo/walkingpad-fitbit/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py", line 100, in monitor
    await ctler.run(device)
  File "/Users/jdoe/gitrepo/walkingpad-fitbit/.venv/lib/python3.12/site-packages/ph4_walkingpad/pad.py", line 426, in run
    value = await client.read_gatt_descriptor(descriptor.handle)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jdoe/gitrepo/walkingpad-fitbit/.venv/lib/python3.12/site-packages/bleak/__init__.py", line 875, in read_gatt_descriptor
    return await self._backend.read_gatt_descriptor(handle, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jdoe/gitrepo/walkingpad-fitbit/.venv/lib/python3.12/site-packages/bleak/backends/corebluetooth/client.py", line 303, in read_gatt_descriptor
    descriptor = self.services.get_descriptor(handle)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_descriptor'
```