### PR TITLE
Send `manualCalories`, with value `0`, to avoid a `500` error in the FitBit server.

### DIFF
--- a/tests/interfaceadapters/walkingpad/test_monitor.py
+++ b/tests/interfaceadapters/walkingpad/test_monitor.py
@@ -52,6 +52,7 @@ MONITOR_DURATION_ELAPSED_SCENARIOS = [
             "distance": pytest.approx(1.253),
             "activityId": 90019,
             "distanceUnit": "Kilometer",
+            "manualCalories": 0,
         },
     ),
     MonitorScenario(
@@ -81,6 +82,7 @@ MONITOR_DURATION_ELAPSED_SCENARIOS = [
             "distance": pytest.approx(1.253),
             "activityId": 90019,
             "distanceUnit": "Kilometer",
+            "manualCalories": 0,
         },
     ),
     MonitorScenario(
@@ -121,6 +123,7 @@ MONITOR_DURATION_ELAPSED_SCENARIOS = [
             "distance": pytest.approx(1.253),
             "activityId": 90019,
             "distanceUnit": "Kilometer",
+            "manualCalories": 0,
         },
     ),
     MonitorScenario(
@@ -145,6 +148,7 @@ MONITOR_DURATION_ELAPSED_SCENARIOS = [
             "distance": pytest.approx(1.253),
             "activityId": 90019,
             "distanceUnit": "Kilometer",
+            "manualCalories": 0,
         },
     ),
 ]
@@ -172,6 +176,7 @@ MONITORING_INTERRUPTED_SCENARIOS = [
             "distance": pytest.approx(1.253),
             "activityId": 90019,
             "distanceUnit": "Kilometer",
+            "manualCalories": 0,
         },
     ),
     MonitorScenario(
@@ -212,6 +217,7 @@ MONITORING_INTERRUPTED_SCENARIOS = [
             "distance": pytest.approx(1.253),
             "activityId": 90019,
             "distanceUnit": "Kilometer",
+            "manualCalories": 0,
         },
     ),
     MonitorScenario(

--- a/walkingpadfitbit/interfaceadapters/fitbit/remoterepository.py
+++ b/walkingpadfitbit/interfaceadapters/fitbit/remoterepository.py
@@ -20,5 +20,6 @@ class FitbitRemoteActivityRepository(RemoteActivityRepository):
                 "distance": activity.distance_km,
                 "activityId": 90019,
                 "distanceUnit": "Kilometer",
+                "manualCalories": 0,
             },
         )


### PR DESCRIPTION
See related issue opened on FitBit: https://community.fitbit.com/t5/Web-API-Development/same-activity-upload-for-some-users-response-500-internal-server-error/m-p/5660030

If we don't send `manualCalories`, the server responds with a `500` error.

Note that FitBit doesn't seem to use the zero value we send: we see non-zero calories appear in the FitBit app for the treadmill activities.