### PR TITLE
Improve interrupt handling

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -10,4 +10,4 @@ fi
 
 source .venv/bin/activate
 pip install --requirement requirements/prod.txt
-python -m walkingpadfitbit.main $*
+exec python -m walkingpadfitbit.main $*

--- a/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
+++ b/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
@@ -114,6 +114,7 @@ async def monitor(
 
 
 def signal_handler(signum, frame):
+    logger.info(f"Signal {signum} received")
     program_end_event.set()
 
 

--- a/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
+++ b/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
@@ -104,6 +104,11 @@ async def monitor(
             break
         await sleep(poll_interval_s)
 
+        # In case the user ctrl-C'd during the sleep, let's
+        # exit early, without checking if we need to reconnect.
+        if program_end_event.is_set():
+            break
+
         if not ctler.client.is_connected:
             logger.info("Got disconnected. Reconnecting...")
             await _safe_call(ctler.disconnect)


### PR DESCRIPTION
* Log when our interrupt signal handler is called.
* In go.sh, use exec, so that it will be as if python were executed directly from the shell.
* Check the if the user tried to interrupt the program, before checking if the client was disonnected.