### PR TITLE
[WIP 🚧 ] Add command to stop the device and put it into standby mode.

### DIFF
--- a/walkingpadfitbit/domain/display/factory.py
+++ b/walkingpadfitbit/domain/display/factory.py
@@ -6,6 +6,11 @@ from walkingpadfitbit.domain.display.plaintext import PlainTextDisplay
 from walkingpadfitbit.domain.display.richtext import RichTextDisplay
 
 
+class Action(enum.StrEnum):
+    MONITOR = "monitor"
+    STOP = "stop"
+
+
 class DisplayMode(enum.StrEnum):
     PLAIN_TEXT = "plaintext"
     RICH_TEXT = "richtext"

--- a/walkingpadfitbit/interfaceadapters/cli/argparser.py
+++ b/walkingpadfitbit/interfaceadapters/cli/argparser.py
@@ -1,7 +1,7 @@
 import argparse
 from typing import Protocol
 
-from walkingpadfitbit.domain.display.factory import DisplayMode
+from walkingpadfitbit.domain.display.factory import Action, DisplayMode
 
 
 class CliArgs(Protocol):
@@ -9,6 +9,7 @@ class CliArgs(Protocol):
     monitor_duration_s: float
     poll_interval_s: float
     display_mode: DisplayMode
+    action: Action
 
 
 def parse_args() -> CliArgs:
@@ -41,6 +42,14 @@ def parse_args() -> CliArgs:
         type=DisplayMode,
         choices=DisplayMode,
         default=DisplayMode.RICH_TEXT,
+    )
+    arg_parser.add_argument(
+        "-a",
+        "--action",
+        help="Action",
+        type=Action,
+        choices=Action,
+        default=Action.MONITOR,
     )
 
     return arg_parser.parse_args()

--- a/walkingpadfitbit/interfaceadapters/walkingpad/device.py
+++ b/walkingpadfitbit/interfaceadapters/walkingpad/device.py
@@ -1,0 +1,22 @@
+import logging
+from typing import Any, Coroutine
+
+from bleak.backends.device import BLEDevice
+from ph4_walkingpad.pad import Scanner
+
+logger = logging.getLogger(__name__)
+
+
+async def get_device(
+    device_name: str,
+) -> Coroutine[Any, Any, BLEDevice]:
+    scanner = Scanner()
+    await scanner.scan(dev_name=device_name.lower())
+
+    if not scanner.walking_belt_candidates:
+        logger.error(f"{device_name} not found")
+        return
+
+    device = scanner.walking_belt_candidates[0]
+    logger.info(f"Found device {device}")
+    return device

--- a/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
+++ b/walkingpadfitbit/interfaceadapters/walkingpad/monitor.py
@@ -5,7 +5,7 @@ import time
 from asyncio import sleep
 from typing import Any, Awaitable, Callable
 
-from ph4_walkingpad.pad import Controller, Scanner, WalkingPadCurStatus
+from ph4_walkingpad.pad import Controller, WalkingPadCurStatus
 
 from walkingpadfitbit.domain.entities.event import (
     TreadmillEvent,
@@ -13,6 +13,7 @@ from walkingpadfitbit.domain.entities.event import (
     TreadmillWalkEvent,
 )
 from walkingpadfitbit.domain.eventhandler import TreadmillEventHandler
+from walkingpadfitbit.interfaceadapters.walkingpad.device import get_device
 
 logger = logging.getLogger(__name__)
 
@@ -70,15 +71,7 @@ async def monitor(
     """
 
     # 1. Find the device with the given name.
-    scanner = Scanner()
-    await scanner.scan(dev_name=device_name.lower())
-
-    if not scanner.walking_belt_candidates:
-        logger.error(f"{device_name} not found")
-        return
-
-    device = scanner.walking_belt_candidates[0]
-    logger.info(f"Found device {device}")
+    device = await get_device(device_name)
 
     # 2. Run the controller for the found device.
     ctler = Controller()

--- a/walkingpadfitbit/interfaceadapters/walkingpad/remotecontrol.py
+++ b/walkingpadfitbit/interfaceadapters/walkingpad/remotecontrol.py
@@ -1,0 +1,24 @@
+import asyncio
+import logging
+
+from ph4_walkingpad.pad import Controller, WalkingPad
+
+from walkingpadfitbit.interfaceadapters.walkingpad.device import get_device
+
+logger = logging.getLogger(__name__)
+
+
+async def stop_device(device_name: str):
+    # 1. Find the device with the given name.
+    device = await get_device(device_name)
+
+    # 2. Run the controller for the found device.
+    ctler = Controller()
+    await ctler.run(device)
+
+    logger.info("Stopping device...")
+    await ctler.stop_belt()
+    logger.info("Stopped device.")
+    await asyncio.sleep(3)
+
+    await ctler.switch_mode(WalkingPad.MODE_STANDBY)

--- a/walkingpadfitbit/main.py
+++ b/walkingpadfitbit/main.py
@@ -5,7 +5,7 @@ import sys
 from walkingpadfitbit.auth.client import get_client
 from walkingpadfitbit.auth.config import Settings
 from walkingpadfitbit.domain.display.base import BaseDisplay
-from walkingpadfitbit.domain.display.factory import get_display
+from walkingpadfitbit.domain.display.factory import Action, get_display
 from walkingpadfitbit.domain.eventhandler import TreadmillEventHandler
 from walkingpadfitbit.interfaceadapters.cli.argparser import CliArgs, parse_args
 from walkingpadfitbit.interfaceadapters.cli.logincli import login_cli
@@ -13,6 +13,7 @@ from walkingpadfitbit.interfaceadapters.fitbit.remoterepository import (
     FitbitRemoteActivityRepository,
 )
 from walkingpadfitbit.interfaceadapters.walkingpad.monitor import monitor
+from walkingpadfitbit.interfaceadapters.walkingpad.remotecontrol import stop_device
 
 
 async def main(
@@ -46,12 +47,18 @@ async def main(
         remote_activity_repository=remote_activity_repository,
         display=display,
     )
-    await monitor(
-        device_name=args.device_name,
-        treadmill_event_handler=treadmill_event_handler,
-        monitor_duration_s=args.monitor_duration_s,
-        poll_interval_s=args.poll_interval_s,
-    )
+
+    if args.action == Action.MONITOR:
+        await monitor(
+            device_name=args.device_name,
+            treadmill_event_handler=treadmill_event_handler,
+            monitor_duration_s=args.monitor_duration_s,
+            poll_interval_s=args.poll_interval_s,
+        )
+    elif args.action == Action.STOP:
+        await stop_device(
+            device_name=args.device_name,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a `--action` optional argument to the command.

The possible values are:
* `monitor` (default)
* `stop`

If `--action monitor` is provided, or `--action` is omitted, the behavior is the same as before.

If `--action stop` is provided, the program will stop the belt and put the device into standby mode.

⚠️ **If there's already a process running the monitoring feature**, **a second invocation of the command, from another window, will not work**. The device isn't found. 

We need to have a way to have a primary process running, and notifying it somehow to perform some commands like stopping. Could be via a shared file, exposing a REST api, a socket...
