### PR TITLE
Specify the title correctly for the api doc.

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,6 +1,9 @@
 {
   "info": {
-    "title": "Treadmill API"
+    "version": "0.0.1",
+    "title": "Treadmill API",
+    "description": "powered by Flasgger",
+    "termsOfService": null
   },
   "paths": {
     "/treadmill/start": {

--- a/walkingpadfitbit/interfaceadapters/restapi/server.py
+++ b/walkingpadfitbit/interfaceadapters/restapi/server.py
@@ -13,10 +13,10 @@ def create_app():
     app = Flask(__name__)
     app.register_blueprint(treadmillbp.bp)
     swagger_config = deepcopy(Swagger.DEFAULT_CONFIG)
-    swagger_config["info"] = {
-        "title": "Treadmill API",
-    }
+    swagger_config["title"] = "Treadmill API"
     swagger_config["specs_route"] = "/"
+    swagger_config["termsOfService"] = None
+
     Swagger(
         app,
         config=swagger_config,


### PR DESCRIPTION
Specify the title as a root config attribute. This means it will appear in the browser tab of the interactive swagger UI page.

Remove the terms of service from the swagger ui.