### PR TITLE
Add toggle route

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ The server exposes two routes:
   ```
   curl -X POST http://127.0.0.1:11198/treadmill/stop
   ```
+* `POST /treadmill/toggle-start-stop`: to start the treadmill if it's running, otherwise stop it.
+  Curl example:
+  ```
+  curl -X POST http://127.0.0.1:11198/treadmill/toggle-start-stop
+  ```
 
 A Swagger UI is available at the root route: http://127.0.0.1:11198/
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -23,10 +23,44 @@
           }
         }
       }
+    },
+    "/treadmill/toggle-start-stop": {
+      "post": {
+        "summary": "Toggle the start/stop state of the treadmill.",
+        "description": "If the treadmill is running, stop it.<br/>If the treadmill isn't running, start it.<br/>",
+        "responses": {
+          "200": {
+            "description": "The treadmill start/stop state was successfully toggled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ToggleResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
-    "schemas": {}
+    "schemas": {
+      "ToggleResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "started",
+              "stopped"
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ]
+      }
+    }
   },
   "openapi": "3.0.0"
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,9 +1,7 @@
 {
   "info": {
-    "version": "0.0.1",
     "title": "Treadmill API",
-    "description": "powered by Flasgger",
-    "termsOfService": null
+    "version": "0.0.1"
   },
   "paths": {
     "/treadmill/start": {
@@ -27,6 +25,8 @@
       }
     }
   },
-  "definitions": {},
-  "swagger": "2.0"
+  "components": {
+    "schemas": {}
+  },
+  "openapi": "3.0.0"
 }

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,9 +1,12 @@
+apispec[marshmallow]==6.7.1
+apispec-webframeworks==1.2.0
 authlib==1.3.1
 dependency-injector==4.43.0
 flasgger==0.9.7.1
 flask[async]==3.0.3
 httpx==0.27.0
 keyring==25.2.1
+marshmallow==3.23.1
 ph4-walkingpad==0.0.7
 pydantic==2.8.2
 python-dotenv==1.0.1

--- a/tests/fakes/ph4_walkingpad/fakecontroller.py
+++ b/tests/fakes/ph4_walkingpad/fakecontroller.py
@@ -16,6 +16,7 @@ class ControllerScenario:
     cur_statuses: list[FakeWalkingPadCurStatus] | None = None
     is_connected_values: list[bool] | None = None
     run_exceptions: list[Exception | None] = None
+    last_status: FakeWalkingPadCurStatus | None = None
 
 
 class FakeController:
@@ -25,6 +26,7 @@ class FakeController:
         self.scenario = scenario if scenario else ControllerScenario()
         self.run_iterations = 0
         self.ask_stats_iterations = 0
+        self.last_status = self.scenario.last_status
 
     async def run(self, *args, **kwargs):
         if self.scenario.run_exceptions and self.run_iterations < len(

--- a/tests/interfaceadapters/restapi/test_restapi.py
+++ b/tests/interfaceadapters/restapi/test_restapi.py
@@ -8,6 +8,10 @@ from pytest import MonkeyPatch
 from werkzeug.test import TestResponse
 
 from tests.fakes.ph4_walkingpad.config import configure_fake_walkingpad
+from tests.fakes.ph4_walkingpad.fakecontroller import (
+    ControllerScenario,
+    FakeWalkingPadCurStatus,
+)
 from tests.fakes.ph4_walkingpad.fakescanner import ScannerScenario
 from walkingpadfitbit import container
 
@@ -18,6 +22,7 @@ class Scenario:
     route: str
     expected_status_code: int
     expected_body: dict[str, Any] | None = None
+    controller_scenario: ControllerScenario | None = None
 
 
 SCENARIOS = [
@@ -30,6 +35,26 @@ SCENARIOS = [
         id="stop",
         route="stop",
         expected_status_code=http.HTTPStatus.NO_CONTENT,
+    ),
+    Scenario(
+        id="toggle started",
+        route="toggle-start-stop",
+        expected_status_code=http.HTTPStatus.OK,
+        expected_body={"status": "started"},
+    ),
+    Scenario(
+        id="toggle stopped",
+        route="toggle-start-stop",
+        expected_status_code=http.HTTPStatus.OK,
+        expected_body={"status": "stopped"},
+        controller_scenario=ControllerScenario(
+            last_status=FakeWalkingPadCurStatus(
+                dist=10,
+                time=5,
+                belt_state=1,
+                speed=1,
+            )
+        ),
     ),
 ]
 
@@ -50,6 +75,7 @@ def test_treadmill_command(
             ScannerScenario(
                 found_addresses=["some address"],
             ),
+            controller_scenario=scenario.controller_scenario,
         )
 
         container.config.set("device.name", "some device")

--- a/walkingpadfitbit/domain/treadmillcontroller.py
+++ b/walkingpadfitbit/domain/treadmillcontroller.py
@@ -21,6 +21,9 @@ class TreadmillController(ABC):
     async def ask_stats(self) -> None: ...
 
     @abstractmethod
+    def is_on(self) -> bool: ...
+
+    @abstractmethod
     async def start(self) -> None: ...
 
     @abstractmethod

--- a/walkingpadfitbit/interfaceadapters/restapi/server.py
+++ b/walkingpadfitbit/interfaceadapters/restapi/server.py
@@ -1,8 +1,10 @@
 from copy import deepcopy
 
 import uvicorn
+from apispec.ext.marshmallow import MarshmallowPlugin
+from apispec_webframeworks.flask import FlaskPlugin
 from asgiref.wsgi import WsgiToAsgi
-from flasgger import Swagger
+from flasgger import APISpec, Swagger
 from flask import Flask
 from uvicorn.config import LOGGING_CONFIG
 
@@ -12,14 +14,28 @@ from walkingpadfitbit.interfaceadapters.restapi import treadmillbp
 def create_app():
     app = Flask(__name__)
     app.register_blueprint(treadmillbp.bp)
-    swagger_config = deepcopy(Swagger.DEFAULT_CONFIG)
-    swagger_config["title"] = "Treadmill API"
-    swagger_config["specs_route"] = "/"
-    swagger_config["termsOfService"] = None
+
+    spec = APISpec(
+        title="Treadmill API",
+        version="0.0.1",
+        openapi_version="3.0.0",
+        plugins=[
+            FlaskPlugin(),
+            MarshmallowPlugin(),
+        ],
+    )
 
     Swagger(
         app,
-        config=swagger_config,
+        config={
+            **Swagger.DEFAULT_CONFIG,
+            "title": spec.title,
+            "specs_route": "/",
+            "openapi": spec.openapi_version,
+        },
+        template=spec.to_flasgger(
+            app,
+        ),
     )
     return app
 

--- a/walkingpadfitbit/interfaceadapters/restapi/server.py
+++ b/walkingpadfitbit/interfaceadapters/restapi/server.py
@@ -35,6 +35,9 @@ def create_app():
         },
         template=spec.to_flasgger(
             app,
+            definitions=[
+                treadmillbp.ToggleResponseSchema,
+            ],
         ),
     )
     return app

--- a/walkingpadfitbit/interfaceadapters/restapi/treadmillbp.py
+++ b/walkingpadfitbit/interfaceadapters/restapi/treadmillbp.py
@@ -1,7 +1,9 @@
+import enum
 from http import HTTPStatus
 
 from dependency_injector.wiring import Provide, inject
-from flask import Blueprint, Response
+from flask import Blueprint, Response, jsonify
+from marshmallow import Schema, fields
 
 from walkingpadfitbit.containers import Container
 from walkingpadfitbit.domain.treadmillcontroller import TreadmillController
@@ -43,3 +45,40 @@ async def stop(
     """
     await ctler.stop()
     return Response(status=HTTPStatus.NO_CONTENT)
+
+
+class Status(enum.StrEnum):
+    started = enum.auto()
+    stopped = enum.auto()
+
+
+class ToggleResponseSchema(Schema):
+    status = fields.Enum(enum=Status, required=True)
+
+
+@bp.route("/toggle-start-stop", methods=("POST",))
+@inject
+async def toggle_start_stop(
+    ctler: TreadmillController = Provide[Container.treadmill_controller],
+):
+    """
+    Toggle the start/stop state of the treadmill.
+    If the treadmill is running, stop it.
+    If the treadmill isn't running, start it.
+    ---
+    responses:
+      200:
+        description: The treadmill start/stop state was successfully toggled.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ToggleResponse"
+    """
+    status = None
+    if ctler.is_on():
+        await ctler.stop()
+        status = Status.stopped
+    else:
+        await ctler.start()
+        status = Status.started
+    return jsonify(ToggleResponseSchema().dump({"status": status}))

--- a/walkingpadfitbit/interfaceadapters/walkingpad/treadmillcontroller.py
+++ b/walkingpadfitbit/interfaceadapters/walkingpad/treadmillcontroller.py
@@ -40,6 +40,10 @@ class WalkingpadTreadmillController(TreadmillController):
     async def ask_stats(self) -> None:
         await self.ctler.ask_stats()
 
+    def is_on(self) -> bool:
+        last_status = self.ctler.last_status
+        return last_status and last_status.belt_state == 1
+
     async def start(self) -> None:
         await self.ctler.switch_mode(WalkingPad.MODE_MANUAL)
         await asyncio.sleep(1)


### PR DESCRIPTION
* Refactor the api doc generation:
  - Use openapi spec 3
  - Use apispec with marshmallow
* Refactor existing restapi tests: make the test parametrization a `Scenario` dataclass, to support different expected results for start/stop/toggle to start/toggle to stop.
* Add the new route `POST /treadmill/toggle-start-stop` which toggles between start and stop states.