### PR TITLE
Use flask-smorest instead of flasgger to generate api doc.

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,33 +1,33 @@
 {
-  "info": {
-    "title": "Treadmill API",
-    "version": "0.0.1"
-  },
   "paths": {
     "/treadmill/start": {
       "post": {
-        "summary": "Start the treadmill.",
         "responses": {
           "204": {
             "description": "The treadmill was successfully started."
           }
-        }
+        },
+        "summary": "Start the treadmill.",
+        "tags": [
+          "treadmill"
+        ]
       }
     },
     "/treadmill/stop": {
       "post": {
-        "summary": "Stop the treadmill.",
         "responses": {
           "204": {
             "description": "The treadmill was successfully stopped."
           }
-        }
+        },
+        "summary": "Stop the treadmill.",
+        "tags": [
+          "treadmill"
+        ]
       }
     },
     "/treadmill/toggle-start-stop": {
       "post": {
-        "summary": "Toggle the start/stop state of the treadmill.",
-        "description": "If the treadmill is running, stop it.<br/>If the treadmill isn't running, start it.<br/>",
         "responses": {
           "200": {
             "description": "The treadmill start/stop state was successfully toggled.",
@@ -39,10 +39,26 @@
               }
             }
           }
-        }
+        },
+        "summary": "Toggle the start/stop state of the treadmill.",
+        "description": "If the treadmill is running, stop it.\n\nIf the treadmill isn't running, start it.",
+        "tags": [
+          "treadmill"
+        ]
       }
     }
   },
+  "info": {
+    "title": "Treadmill API",
+    "version": "0.0.1"
+  },
+  "tags": [
+    {
+      "name": "treadmill",
+      "description": ""
+    }
+  ],
+  "openapi": "3.0.2",
   "components": {
     "schemas": {
       "ToggleResponse": {
@@ -61,6 +77,5 @@
         ]
       }
     }
-  },
-  "openapi": "3.0.0"
+  }
 }

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,9 +1,8 @@
 apispec[marshmallow]==6.7.1
-apispec-webframeworks==1.2.0
 authlib==1.3.1
 dependency-injector==4.43.0
-flasgger==0.9.7.1
 flask[async]==3.0.3
+flask-smorest==0.45.0
 httpx==0.27.0
 keyring==25.2.1
 marshmallow==3.23.1

--- a/scripts/create_doc.py
+++ b/scripts/create_doc.py
@@ -1,10 +1,12 @@
 import json
+from apispec import APISpec
+from flask_smorest import Api
 from walkingpadfitbit.interfaceadapters.restapi import server
 
 app = server.create_app()
 
-with app.app_context():
-    openapi_spec = app.swag.get_apispecs("apispec_1")
-
-openapi_spec_json = json.dumps(openapi_spec, indent=2)
+api: Api = app.extensions["flask-smorest"]["apis"][""]["ext_obj"]
+openapi_spec: APISpec = api.spec
+openapi_spec_dict = openapi_spec.to_dict()
+openapi_spec_json = json.dumps(openapi_spec_dict, indent=2)
 print(openapi_spec_json)

--- a/walkingpadfitbit/interfaceadapters/restapi/flaskutils.py
+++ b/walkingpadfitbit/interfaceadapters/restapi/flaskutils.py
@@ -1,0 +1,21 @@
+from functools import wraps
+from inspect import iscoroutinefunction
+
+from asgiref.sync import async_to_sync
+
+
+def ensure_sync(func):
+    """
+    Add this decorator to async views, before adding decorators
+    from other extensions (like flask_smorest) which don't support
+    async views.
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if iscoroutinefunction(func):
+            return async_to_sync(func)(*args, **kwargs)
+
+        return func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
Pros:
- Less "yaml-type" text to put in docstr for routes.
- Slightly less configuration to setup the app.
- The marshmallow schema is used to validate and serialize the response.

Cons:
- Need to use a different `Blueprint` class.
- This `Blueprint` class doesn't support async views, so we need to add another decorator to transition from async to sync.