### PR TITLE
From tests, spy the controller and assert method calls on it.

### DIFF
--- a/tests/fakes/ph4_walkingpad/config.py
+++ b/tests/fakes/ph4_walkingpad/config.py
@@ -9,9 +9,12 @@ def configure_fake_walkingpad(
     mp: pytest.MonkeyPatch,
     scanner_scenario: ScannerScenario | None = None,
     controller_scenario: ControllerScenario | None = None,
-):
+) -> tuple[FakeScanner, FakeController]:
     """
     Use fake replacements for walkingpad apis
     """
-    mp.setattr(Scanner, "__new__", lambda _: FakeScanner(scanner_scenario))
-    mp.setattr(Controller, "__new__", lambda _: FakeController(controller_scenario))
+    fake_scanner = FakeScanner(scanner_scenario)
+    fake_controller = FakeController(controller_scenario)
+    mp.setattr(Scanner, "__new__", lambda _: fake_scanner)
+    mp.setattr(Controller, "__new__", lambda _: fake_controller)
+    return fake_scanner, fake_controller

--- a/tests/interfaceadapters/restapi/test_restapi.py
+++ b/tests/interfaceadapters/restapi/test_restapi.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 from flask.testing import FlaskClient
+from ph4_walkingpad.pad import WalkingPad
 from pytest import MonkeyPatch
 from werkzeug.test import TestResponse
 
@@ -13,6 +14,7 @@ from tests.fakes.ph4_walkingpad.fakecontroller import (
     FakeWalkingPadCurStatus,
 )
 from tests.fakes.ph4_walkingpad.fakescanner import ScannerScenario
+from tests.spy import Call, Spy
 from walkingpadfitbit import container
 
 
@@ -21,6 +23,7 @@ class Scenario:
     id: str
     route: str
     request_input: dict[str, Any] | None
+    expected_controller_method_calls: list[Call]
     expected_status_code: int
     expected_body: dict[str, Any] | None = None
     controller_scenario: ControllerScenario | None = None
@@ -31,18 +34,30 @@ SCENARIOS = [
         id="start",
         route="start",
         request_input=None,
+        expected_controller_method_calls=[
+            Call("switch_mode", (WalkingPad.MODE_MANUAL,)),
+            Call("start_belt"),
+        ],
         expected_status_code=http.HTTPStatus.NO_CONTENT,
     ),
     Scenario(
         id="stop",
         route="stop",
         request_input=None,
+        expected_controller_method_calls=[
+            Call("stop_belt"),
+            Call("switch_mode", (WalkingPad.MODE_STANDBY,)),
+        ],
         expected_status_code=http.HTTPStatus.NO_CONTENT,
     ),
     Scenario(
         id="toggle started",
         route="toggle-start-stop",
         request_input=None,
+        expected_controller_method_calls=[
+            Call("switch_mode", (WalkingPad.MODE_MANUAL,)),
+            Call("start_belt"),
+        ],
         expected_status_code=http.HTTPStatus.OK,
         expected_body={"status": "started"},
     ),
@@ -50,6 +65,10 @@ SCENARIOS = [
         id="toggle stopped",
         route="toggle-start-stop",
         request_input=None,
+        expected_controller_method_calls=[
+            Call("stop_belt"),
+            Call("switch_mode", (WalkingPad.MODE_STANDBY,)),
+        ],
         expected_status_code=http.HTTPStatus.OK,
         expected_body={"status": "stopped"},
         controller_scenario=ControllerScenario(
@@ -65,6 +84,9 @@ SCENARIOS = [
         id="Set speed",
         route="set-speed",
         request_input={"speed_kph": 2.5},
+        expected_controller_method_calls=[
+            Call("change_speed", (25,)),
+        ],
         expected_status_code=http.HTTPStatus.NO_CONTENT,
         expected_body=None,
     ),
@@ -72,6 +94,7 @@ SCENARIOS = [
         id="Set speed with invalid value",
         route="set-speed",
         request_input={"speed_kph": -1.0},
+        expected_controller_method_calls=[],
         expected_status_code=http.HTTPStatus.UNPROCESSABLE_ENTITY,
         expected_body={"code": 422},
     ),
@@ -79,6 +102,9 @@ SCENARIOS = [
         id="increase speed by 0.5",
         route="change-speed-by",
         request_input={"speed_delta_kph": 0.5},
+        expected_controller_method_calls=[
+            Call("change_speed", (45,)),
+        ],
         expected_status_code=http.HTTPStatus.OK,
         expected_body={"new_speed_kph": pytest.approx(4.5)},
         controller_scenario=ControllerScenario(
@@ -94,6 +120,9 @@ SCENARIOS = [
         id="decrease speed by 0.5",
         route="change-speed-by",
         request_input={"speed_delta_kph": -0.5},
+        expected_controller_method_calls=[
+            Call("change_speed", (35,)),
+        ],
         expected_status_code=http.HTTPStatus.OK,
         expected_body={"new_speed_kph": pytest.approx(3.5)},
         controller_scenario=ControllerScenario(
@@ -109,6 +138,7 @@ SCENARIOS = [
         id="increase speed by too large number",
         route="change-speed-by",
         request_input={"speed_delta_kph": 100.0},
+        expected_controller_method_calls=[],
         expected_status_code=http.HTTPStatus.UNPROCESSABLE_ENTITY,
         expected_body={"code": 422},
         controller_scenario=ControllerScenario(
@@ -124,6 +154,9 @@ SCENARIOS = [
         id="increase speed when no previous speed",
         route="change-speed-by",
         request_input={"speed_delta_kph": 0.8},
+        expected_controller_method_calls=[
+            Call("change_speed", (8,)),
+        ],
         expected_status_code=http.HTTPStatus.OK,
         expected_body={"new_speed_kph": pytest.approx(0.8)},
         controller_scenario=ControllerScenario(),
@@ -132,6 +165,9 @@ SCENARIOS = [
         id="decrease speed to be negative",
         route="change-speed-by",
         request_input={"speed_delta_kph": -1.0},
+        expected_controller_method_calls=[
+            Call("change_speed", (0,)),
+        ],
         expected_status_code=http.HTTPStatus.OK,
         expected_body={"new_speed_kph": 0.0},
         controller_scenario=ControllerScenario(
@@ -157,14 +193,14 @@ def test_treadmill_command(
     scenario: Scenario,
 ):
     with monkeypatch.context() as mp:
-        configure_fake_walkingpad(
+        _, fake_controller = configure_fake_walkingpad(
             mp,
             ScannerScenario(
                 found_addresses=["some address"],
             ),
             controller_scenario=scenario.controller_scenario,
         )
-
+        spy = Spy(fake_controller)
         container.config.set("device.name", "some device")
         response: TestResponse = restapi_client.post(
             f"/treadmill/{scenario.route}",
@@ -178,3 +214,5 @@ def test_treadmill_command(
             # Don't compare the full contents: in the case of errors, the framework adds some detailed error messages
             # for which we don't need to assert the exact content.
             assert response.json.items() >= scenario.expected_body.items()
+
+        assert spy.method_calls == scenario.expected_controller_method_calls

--- a/tests/spy.py
+++ b/tests/spy.py
@@ -1,0 +1,46 @@
+import dataclasses
+from inspect import iscoroutinefunction, ismethod
+from typing import Any, Callable
+
+
+@dataclasses.dataclass
+class Call:
+    name: str
+    args: tuple = ()
+    kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+class Spy:
+    """
+    Spy all method calls on the given object.
+
+    The method calls will be available is the method_calls field, which is a list of Call.
+    """
+
+    def __init__(self, obj) -> None:
+        self.method_calls: list[Call] = []
+        self._spy_all_methods(obj)
+
+    def _spy_all_methods(self, obj):
+        method_names = [attr for attr in dir(obj) if ismethod(getattr(obj, attr))]
+
+        for method_name in method_names:
+            method = getattr(obj, method_name)
+            if iscoroutinefunction(method):
+                self._spy_async_method(obj, method)
+            else:
+                self._spy_sync_method(obj, method)
+
+    def _spy_sync_method(self, obj, func: Callable):
+        def wrapper(*args, **kwargs):
+            self.method_calls.append(Call(func.__name__, args=args, kwargs=kwargs))
+            return func(*args, **kwargs)
+
+        setattr(obj, func.__name__, wrapper)
+
+    def _spy_async_method(self, obj, func: Callable):
+        async def wrapper(*args, **kwargs):
+            self.method_calls.append(Call(func.__name__, args=args, kwargs=kwargs))
+            return await func(*args, **kwargs)
+
+        setattr(obj, func.__name__, wrapper)


### PR DESCRIPTION
Why? 

We should have assertions that check that our rest api actually calls calls the controller as expected, and specifically, that our controller does the appropriate conversions between the weird walkingpad units for speed and normal km/h speed.
    

How?

Create a `Spy` class which logs all calls to all methods in an object.
    
In the restapi tests, define expected calls to the controller in the scenarios, and assert that these methods were actually called.